### PR TITLE
chore: add publish workflow for crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: Publish to crates.io
+on:
+  workflow_dispatch:
+jobs:
+  publish-crate:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish -p candid-extractor
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
- Add a `publish.yml` workflow for publishing to crates.io using trusted publishing (OIDC-based auth via `crates-io-auth-action`)
- Triggered manually via `workflow_dispatch`